### PR TITLE
Fix aggressive data caching in react components

### DIFF
--- a/app/javascript/components/AddRepoPage.js
+++ b/app/javascript/components/AddRepoPage.js
@@ -62,10 +62,14 @@ class AddRepoPage extends React.Component {
 
     const query = new URLSearchParams(props.location.search)
 
+    // Restore the cache only if the user navigated back to this page.
+    const availableRepos = this.props.history.action == 'POP' &&
+      this.props.location.state && this.props.location.state.availableRepos
+
     // Get whatever state we want to restore from the location state.
     // This will allow seamless navigation back to this page, since we set the state when we finished fetching.
     this.state = {
-      availableRepos: this.props.location.state && this.props.location.state.availableRepos,
+      availableRepos,
       searchTerm: query.get('q') || '',
       isFetchingRepos: false,
       wasServerError: false,

--- a/app/javascript/components/RepoPage.js
+++ b/app/javascript/components/RepoPage.js
@@ -8,28 +8,43 @@ class RepoPage extends React.Component {
   constructor(props) {
     super(props)
 
+    // Restore the cache only if the user navigated back to this page.
+    const repo = this.props.history.action == 'POP' &&
+      this.props.location.state && this.props.location.state.repo
+
     this.state = {
-      repo: null,
+      repo,
       isFetchingRepo: false,
       wasServerError: false,
     }
   }
 
   componentDidMount() {
-    this.fetchRepo()
+    if (!this.state.repo) {
+      this.fetchRepo()
+    }
   }
 
   shouldComponentUpdate(nextProps, nextState) {
     // If the route changes while this component is already opened, it won't get remounted.
     // So look for the route data to change and load the new repo.
-    if (nextProps.match !== this.props.match) {
+    if (nextProps.match.url !== this.props.match.url) {
       this.fetchRepo()
     }
 
-    // If the fetched repo has a different path, it's likely been renamed, so we want to redirect to the new name
-    // seamlessly.
-    if (this.state.repo && this.state.repo.path !== nextState.repo.path) {
-      window.history.replace(nextState.repo.path)
+    if (nextState.repo != this.state.repo && !nextState.isFetchingRepo) {
+      // Store the repo in our location state so it will be restored when navigating back.
+      if (this.state.repo && this.state.repo.path !== nextState.repo.path) {
+        // If the fetched repo has a different path, it's likely been renamed, so we want to redirect to the new name
+        // seamlessly.
+        window.history.replace({ pathname: newState.repo.path, state: {
+          repo: this.state.repo,
+        } })
+      } else {
+        this.props.history.replace({ ...this.props.location, state: {
+          repo: this.state.repo,
+        } })
+      }
     }
 
     return true


### PR DESCRIPTION
It was set to place the state in the router history object. However, it was restoring that every time the component mounted, which made it impossible to reload the page.

Now it will only load the state from the history object if the last action was a "pop" in other words, navigation Back.

Also, the RepoPage was not caching the repo data at all, and now it is.
