### PR TITLE
Fix complaints about APPLICATION_REVISION

### DIFF
--- a/app/views/layouts/_sentry.html.erb
+++ b/app/views/layouts/_sentry.html.erb
@@ -3,7 +3,7 @@
     window.SentryConfig = {
       dsn: '<%= Rails.configuration.x.sentry['javascript_dsn'] %>',
       environment: '<%= ENV['RAILS_ENV'] %>',
-      release: '<%= APPLICATION_REVISION %>',
+      release: '<%= ApplicationRelease.current %>',
       xhrUrlIgnorePattern: /smartlook|mixpanel|google-analytics/,
       user: <%- if current_user.present? -%>
         {

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,15 +1,13 @@
-require_relative 'revision'
+# frozen_string_literal: true
 
-if ENV['SENTRY_DSN']
-  Raven.configure do |config|
-    config.excluded_exceptions += %w[SignalException]
+Raven.configure do |config|
+  config.excluded_exceptions += %w[SignalException]
 
-    # Send POST data
-    config.processors -= [Raven::Processor::PostData]
+  # Send POST data
+  config.processors -= [Raven::Processor::PostData]
 
-    # Send cookies
-    # config.processors -= [Raven::Processor::Cookies]
+  # Send cookies
+  # config.processors -= [Raven::Processor::Cookies]
 
-    config.release = ApplicationRelease.current
-  end
+  config.release = ApplicationRelease.current
 end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -2,11 +2,14 @@ require_relative 'revision'
 
 if ENV['SENTRY_DSN']
   Raven.configure do |config|
-    # config.excluded_exceptions = %w[
-    #   ActionController::RoutingError
-    #   SidekiqWorkerFailure
-    #   InsufficientPermissionError
-    # ]
-    config.release = APPLICATION_REVISION
+    config.excluded_exceptions += %w[SignalException]
+
+    # Send POST data
+    config.processors -= [Raven::Processor::PostData]
+
+    # Send cookies
+    # config.processors -= [Raven::Processor::Cookies]
+
+    config.release = ApplicationRelease.current
   end
 end

--- a/lib/application_release.rb
+++ b/lib/application_release.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 ##
-# Gets the current version of the application.
-class RevisionFinder
+# Gets the current release name of the application.
+class ApplicationRelease
   class << self
-    def revision
-      release_from_capistrano || revision_from_capistrano || test_revision || "development"
+    def current
+      @current ||= release_from_capistrano || revision_from_capistrano || test_revision || "development"
     end
 
     private
@@ -25,5 +27,3 @@ class RevisionFinder
     end
   end
 end
-
-APPLICATION_REVISION = RevisionFinder.revision


### PR DESCRIPTION
Replace the initializer with a simple class that does the job of finding the current release name. Also, add POST data to Sentry reports.
